### PR TITLE
Add missing & between url parameters

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -77,7 +77,7 @@ export async function getDweets(
   return get(
     `dweets/?offset=${page * 10}&username=${encodeURIComponent(
       username
-    )}order_by=${encodeURIComponent(order_by)}&hashtag=${encodeURIComponent(
+    )}&order_by=${encodeURIComponent(order_by)}&hashtag=${encodeURIComponent(
       hashtag
     )}`
   );


### PR DESCRIPTION
After updating the API, this broke loading of dweets. Works locally now