### PR TITLE
Add top feeds and u/username h/hashtag without /new /top etc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,6 +282,11 @@ function App() {
               component={HotHashtagFeed}
             />
             <Route
+              path="/h/:hashtag"
+              exact={true}
+              component={HotHashtagFeed}
+            />
+            <Route
               path="/h/:hashtag/new"
               exact={true}
               component={NewHashtagFeed}
@@ -293,6 +298,11 @@ function App() {
             />
             <Route
               path="/u/:username/hot"
+              exact={true}
+              component={HotUserFeed}
+            />
+            <Route
+              path="/u/:username"
               exact={true}
               component={HotUserFeed}
             />


### PR DESCRIPTION
Depends on https://github.com/lionleaf/dwitter/pull/489 which adds support for awesome_count

Also adds the paths without /new /hot etc, defaulting to the hot sort method.  (Maybe there's a better way to do this, with an alias? Or can you use regex in the url definition?)