### PR TITLE
Add report dweet functionality

### DIFF
--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef, useContext } from "react";
 import { Dweet, setLike, addComment } from "./api";
 import { UserView } from "./UserView";
+import { ReportButton } from "./ReportButton";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-javascript";
 import "ace-builds/src-noconflict/theme-monokai";
@@ -218,6 +219,7 @@ export const DweetCard: React.FC<Props> = (props) => {
             </div>
           </div>
         </div>
+        <ReportButton dweetId={dweet.id} isEmptyStateDweet={isEmptyStateDweet} />
         <a
           href="#"
           style={{

--- a/src/ReportButton.tsx
+++ b/src/ReportButton.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useContext } from "react";
+import { Context } from "./Context";
+import { reportDweet } from "./api";
+
+export const ReportButton: React.FC<{ dweetId : number, isEmptyStateDweet : boolean }> = (props) => {
+  const [hasReported, setHasReported] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [context, _] = useContext(Context);
+  return (
+        <a
+            href="#"
+            style={{
+                marginLeft: 16,
+                    ...(props.isEmptyStateDweet
+                        ? { background: "var(--blue)", borderRadius: 4, opacity: 0.33 }
+                        : {}),
+                    ...(hasReported
+                        ? {color: "gray"}
+                        : {}),
+            }}
+            onClick={async (e) => {
+                e.preventDefault();
+
+                if (hasReported){
+                    return;
+                }
+                if (!window.confirm(
+                    'Are you sure you want to report this to a moderator?')) {
+                    return;
+                }
+                try {
+                    await context.requireLogin({
+                        reason:
+                        "You need to log in in order to report this dweet! Log in now, the dweet will be reported",
+                        nextAction: "report dweet",
+                    });
+                } catch {
+                    return;
+                }
+
+                setIsLoading(true);
+                try{
+                    await reportDweet(props.dweetId)
+                    setHasReported(true);
+                }catch{
+                    alert("Something went wrong when trying to report this dweet. If this persists, let us know on discord");
+                    setHasReported(false);
+                }finally{
+                    setIsLoading(false);
+                }
+            }
+            }
+        >
+            {isLoading ? 'Reporting' : hasReported ? 'Reported' : 'Report'}
+        </a>
+  );
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -121,6 +121,12 @@ export async function addComment(
   });
 }
 
+export async function reportDweet(dweetId: number) {
+  return post(`dweets/${dweetId}/report/`, {
+    data: {},
+  });
+}
+
 export async function postDweet(code: string, comment?: string) {
   return post(`dweets/`, {
     data: {


### PR DESCRIPTION
Adds a basic "report" button to the dweets. Requires changes in the backend (see https://github.com/lionleaf/dwitter/pull/490 ).

Fixes #19 