### PR TITLE
Add remix button

### DIFF
--- a/src/Create.tsx
+++ b/src/Create.tsx
@@ -106,6 +106,7 @@ export const Create: React.FC<RouteComponentProps> = (props) => {
               <button
                 className="btn btn-primary shadow-primary"
                 style={{ flexShrink: 0, marginLeft: 16 }}
+                disabled={[...code].length > 140}
               >
                 Post dweet
               </button>

--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -362,7 +362,7 @@ export const DweetCard: React.FC<Props> = (props) => {
                 "btn " +
                 (hasDweetChanged ?  "btn-primary" : "btn-secondary")
               }
-              disabled={ !hasDweetChanged || isEmptyStateDweet}
+              disabled={ !hasDweetChanged || isEmptyStateDweet || [...code].length > 140 }
             >
               Post as Remix
             </button>

--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useContext } from "react";
-import { Dweet, setLike, addComment } from "./api";
+import { Dweet, setLike, addComment, postDweet } from "./api";
 import { UserView } from "./UserView";
 import { ReportButton } from "./ReportButton";
 import AceEditor from "react-ace";
@@ -8,11 +8,12 @@ import "ace-builds/src-noconflict/theme-monokai";
 import { Modal } from "reactstrap";
 import Linkify from "react-linkify";
 import { Context } from "./Context";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 import hljs from "highlight.js/lib/core";
 import javascriptHLJS from "highlight.js/lib/languages/javascript";
 
 hljs.registerLanguage("js", javascriptHLJS);
+
 
 interface Props {
   dweet: Dweet | null;
@@ -46,6 +47,12 @@ export const DweetCard: React.FC<Props> = (props) => {
   const [updatedDweet, setUpdatedDweet] = useState<Dweet | null>(null);
   const [replyText, setReplyText] = useState("");
   const [originalShouldShowIframe, setShouldShowIframe] = useState(false);
+
+  const [remixText, setRemixText] = useState("");
+  const [hasDweetChanged, setHasDweetChanged] = useState(false);
+  const [hasCodeBeenFocused, setHasCodeBeenFocused] = useState(false);
+
+  const [newDweetRedirect, setNewDweetRedirect] = useState<string | null>(null);
 
   const [context, _] = useContext(Context);
 
@@ -87,6 +94,7 @@ export const DweetCard: React.FC<Props> = (props) => {
   };
 
   const [code, setCode] = useState(dweet?.code || "");
+  const [originalCode, setOriginalCode] = useState(dweet?.code || "");
 
   const shouldStickyFirstComment =
     dweet.comments.length > 0 &&
@@ -285,8 +293,12 @@ export const DweetCard: React.FC<Props> = (props) => {
               value={code}
               mode="javascript"
               theme="monokai"
+              onFocus={() => {
+                setHasCodeBeenFocused(true);
+              }}
               onChange={(code) => {
                 setCode(code);
+                setHasDweetChanged(code != originalCode);
               }}
               style={{
                 width: "100%",
@@ -306,6 +318,58 @@ export const DweetCard: React.FC<Props> = (props) => {
           >
             {new Date(dweet.posted).toLocaleString()}
           </a>
+        </div>
+        <div>
+      <form
+        style={{ marginTop: 32 }}
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const new_dweet = await postDweet(code, remixText, dweet.id);
+          setNewDweetRedirect("/d/" + new_dweet.id);
+        }}
+      >
+        {newDweetRedirect &&
+           <Redirect to={newDweetRedirect} />
+        }
+        <div
+          className={remixText ? "shadow-primary border-radius" : ""}
+          style={{ position: "relative",
+                    display: hasCodeBeenFocused ? "block" : "none" }}
+        >
+          <input
+            type="text"
+            disabled={isEmptyStateDweet}
+            ref={inputRef}
+            style={{paddingRight: 64,
+                    background: "transparent",
+                    color: "white",
+                    borderColor: "gray",
+                    border: "1px solid",
+                    }}
+            placeholder={hasDweetChanged ? "Add a caption here..." : "Change the code..."}
+            className="form-control"
+            value={remixText}
+            onChange={(e) => setRemixText(e.target.value)}
+          />
+          <div style={{ position: "absolute", right: 0, top: 0, bottom: 0 }}>
+            <button
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                ...(isEmptyStateDweet ? { color: "#0000" } : {}),
+              }}
+              className={
+                "btn " +
+                (hasDweetChanged ?  "btn-primary" : "btn-secondary")
+              }
+              disabled={ !hasDweetChanged || isEmptyStateDweet}
+            >
+              Post as Remix
+            </button>
+          </div>
+        </div>
+      </form>
+
         </div>
       </div>
       {shouldStickyFirstComment && (
@@ -516,3 +580,5 @@ export const DweetCard: React.FC<Props> = (props) => {
     </div>
   );
 };
+
+

--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -310,7 +310,8 @@ export const DweetCard: React.FC<Props> = (props) => {
             />
           )}
         </div>
-        {"}"} // {[...code].length}/140
+    {"} //"} <span style={{color: [...code].length > 140 ? "red" : "inherit"}}>
+        {[...code].length}/140</span>
         <div style={{ float: "right" }}>
           <a
             className="no-link-styling"

--- a/src/api.ts
+++ b/src/api.ts
@@ -127,11 +127,12 @@ export async function reportDweet(dweetId: number) {
   });
 }
 
-export async function postDweet(code: string, comment?: string) {
+export async function postDweet(code: string, comment?: string, remix_of?: number) {
   return post(`dweets/`, {
     data: {
       code,
       "first-comment": comment,
+      "remix_of": remix_of,
     },
   });
 }


### PR DESCRIPTION
<img width="643" alt="Screen Shot 2020-05-24 at 8 06 13 PM" src="https://user-images.githubusercontent.com/610925/82774611-2c5e8c00-9dfa-11ea-952a-ea10b6bf22ba.png">

Remix button has similar behavior to current dwitter:
- Pops up first time you focus the code of a dweet.
- Tells you to change the code if you haven't
- Enables to "post remix" button and suggests adding a caption once the code has been changed.

Relies on changes to the api to properly create the remix link in the created dweet. Pull request incoming for that.

Resolves #29 

Happy for someone to do a styling pass after this has been merged.