### PR TITLE
Handle display of long usernames

### DIFF
--- a/src/UserView.tsx
+++ b/src/UserView.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 import { User } from "./api";
 import { Link } from "react-router-dom";
 
@@ -19,6 +19,13 @@ function avatar(user: User, right: boolean) {
 }
 
 export const UserView: React.FC<{ user: User; link?: boolean }> = (props) => {
+  const style: CSSProperties = {
+    fontWeight: "bold",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    maxWidth: 256 - 32,
+  };
   return (
     <div
       style={{
@@ -30,10 +37,10 @@ export const UserView: React.FC<{ user: User; link?: boolean }> = (props) => {
 
       {props.link !== false ? (
         <Link to={"/u/" + props.user.username} className="no-link-color">
-          <div style={{ fontWeight: "bold" }}>{props.user.username}</div>
+          <div style={style}>{props.user.username}</div>
         </Link>
       ) : (
-        <div style={{ fontWeight: "bold" }}>{props.user.username}</div>
+        <div style={style}>{props.user.username}</div>
       )}
     </div>
   );


### PR DESCRIPTION
This fixes dwitter-net/dwitter-frontend#56 - Responsive collapse of
username.

<pre align=center><img  width=200 alt src="https://user-images.githubusercontent.com/578029/97639856-b660ef80-1a3f-11eb-958a-1104ef76d879.png"></pre>
