### PR TITLE
Make username overflow responsive + dropping username on mobile

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -69,7 +69,7 @@ body {
     }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 750px) {
     .create-dweet-label {
         display: none;
     }
@@ -78,6 +78,12 @@ body {
 @media (max-width: 660px) {
     .plus-icon {
         margin: 0;
+    }
+}
+
+@media (max-width: 680px) {
+    header .settings-dropdown .username-text {
+        display: none;
     }
 }
 

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -94,7 +94,8 @@ export const Header: React.FC<{}> = (props) => {
           alignItems: "center",
           flex: 1,
           textAlign: "center",
-          whiteSpace: "nowrap"
+          whiteSpace: "nowrap",
+          width: "100%"
         }}
       >
         <div style={{ marginRight: 32 }}>
@@ -233,12 +234,14 @@ export const Header: React.FC<{}> = (props) => {
           <Dropdown
             isOpen={isUserMenuDropdownOpen}
             toggle={() => setIsUserMenuDropdownOpen(!isUserMenuDropdownOpen)}
-            style={{ marginRight: -16 }}
+            style={{ marginRight: -16, minWidth: 0 }}
+            className="settings-dropdown"
           >
             <DropdownToggle
               style={{
                 paddingLeft: 16,
                 paddingRight: 16,
+                width: "100%"
               }}
             >
               <UserView user={context.user} link={false} />

--- a/src/UserView.tsx
+++ b/src/UserView.tsx
@@ -18,13 +18,19 @@ function avatar(user: User, right: boolean) {
   return <img src={user.avatar} alt="" style={style} />;
 }
 
+function username(user: User){
+  return <span style={{ fontWeight: "bold" }} className="username-text">
+            <span style={{ opacity: "0.5" }}>u/</span>
+            {user.username}
+          </span>
+}
+
 export const UserView: React.FC<{ user: User; link?: boolean }> = (props) => {
   const style: CSSProperties = {
     fontWeight: "bold",
     overflow: "hidden",
     whiteSpace: "nowrap",
     textOverflow: "ellipsis",
-    maxWidth: 256 - 32,
   };
   return (
     <div
@@ -37,10 +43,14 @@ export const UserView: React.FC<{ user: User; link?: boolean }> = (props) => {
 
       {props.link !== false ? (
         <Link to={"/u/" + props.user.username} className="no-link-color">
-          <div style={style}>{props.user.username}</div>
+          <div style={style}>
+            { username(props.user) }
+          </div>
         </Link>
       ) : (
-        <div style={style}>{props.user.username}</div>
+        <div style={style}>
+          { username(props.user) }
+        </div>
       )}
     </div>
   );
@@ -50,10 +60,7 @@ export const UserViewRight: React.FC<{ user: User }> = (props) => {
   return (
     <>
       <Link to={"/u/" + props.user.username} className="no-link-color">
-        <span style={{ fontWeight: "bold" }}>
-          <span style={{ opacity: "0.5" }}>u/</span>
-          {props.user.username}
-        </span>
+          { username(props.user) }
       </Link>
       {avatar(props.user, true)}
     </>


### PR DESCRIPTION
Previously the ellipsis just showed up at a predetermined width, and the
width from the window didn't propegate properly. This fixes that, adds a
media query to remove the entire username from the menu when the screen
is narrow enough

Also consistently adds u/ in front of usernames.


(ignore the new dweet button, will get fixed by #65 )
**Full collapse**
![image](https://user-images.githubusercontent.com/610925/97774679-2bebbf00-1b17-11eb-95c6-08dc1e4d2ec5.png)

**Partial username**
![image](https://user-images.githubusercontent.com/610925/97774720-6c4b3d00-1b17-11eb-83c9-6b2ee94eeedd.png)
![image](https://user-images.githubusercontent.com/610925/97774715-5a699a00-1b17-11eb-8fe0-92da22b5f464.png)

**Full username**
![image](https://user-images.githubusercontent.com/610925/97774730-7ec57680-1b17-11eb-98cc-f65f7f5dc2ea.png)

