### PR TITLE
Add whiteSpace:"nowrap" to <Header> for less responsive breakage

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -75,6 +75,7 @@ export const Header: React.FC<{}> = (props) => {
           alignItems: "center",
           flex: 1,
           textAlign: "center",
+          whiteSpace: "nowrap"
         }}
       >
         <div style={{ marginRight: 32 }}>
@@ -196,7 +197,7 @@ export const Header: React.FC<{}> = (props) => {
           )}
         </div>
         <div style={{ flex: 1 }} />
-        <div className="create-new-dweet">
+        <div className="create-new-dweet" >
           <NavLink 
             to="/create"
             className="btn btn-primary d-flex align-items-center justify-content-center"


### PR DESCRIPTION
This prevents the "New Dweet" button as well as the "Log In" link to
break into two lines at the whitespace.

This could happen **before:**
![image](https://user-images.githubusercontent.com/610925/97774798-365a8880-1b18-11eb-986e-6e96630ae4da.png)
