### PR TITLE
Add a little whitespace to login form register link

### DIFF
--- a/src/LoginForm.tsx
+++ b/src/LoginForm.tsx
@@ -104,10 +104,7 @@ export const LoginForm = (props: Props) => {
           alignItems: 'center',
         }}
       >
-        <Link
-          className="mb-3 mt-3"
-          to="/accounts/register"
-        >
+        <Link className="mb-3 mt-3 mr-3" to="/accounts/register">
           Register
         </Link>
         <button


### PR DESCRIPTION
Turns this:
<pre align="center"><img width="200" alt src="https://user-images.githubusercontent.com/578029/138550537-361290d3-161b-4cce-8316-c83d37d3e018.png" /></pre>

into this:
<pre align="center"><img width="200" alt src="https://user-images.githubusercontent.com/578029/138550524-c69ec333-8fad-429c-a7f4-04dc682d6f19.png" /></pre>
