### PR TITLE
Fix double count bug in AwesomeButton

### DIFF
--- a/src/AwesomeButton.tsx
+++ b/src/AwesomeButton.tsx
@@ -18,7 +18,9 @@ export const AwesomeButton: React.FC<{
     setHasUserAwesomed(dweet?.has_user_awesomed || false);
     if (dweet && dweet.id !== 1) {
       setCachedAwesomeCountForAnimation((old) =>
-        old === -1 ? dweet.awesome_count : old
+        old === -1
+          ? dweet.awesome_count - (dweet.has_user_awesomed ? 1 : 0)
+          : old
       );
     }
   }, [dweet]);


### PR DESCRIPTION
Because of how the animation works, we would accidentally show `likes + 1`
instead of `likes` if the user loaded the dweet in an already-liked
state. This fixes that issue.
