### PR TITLE
Fix '1 remixes' singular grammar issue

### DIFF
--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -277,7 +277,7 @@ export const DweetCard: React.FC<Props> = (props) => {
               setShowRemixListModal(true);
             }}
           >
-            {dweet.remixes.length} remixes
+            {dweet.remixes.length} remix{dweet.remixes.length > 1 && 'es'}
           </a>
         )}
         <a


### PR DESCRIPTION
Now properly says '1 remix', '2 remixes' ...

As mentioned on this issue: https://github.com/lionleaf/dwitter/issues/527 