### PR TITLE
Delete dweets and comments

### DIFF
--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -6,9 +6,10 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import { Dweet, addComment, postDweet, getDweet } from './api';
+import { Dweet, DweetComment, addComment, postDweet, getDweet } from './api';
 import { UserView, UserViewRight } from './UserView';
 import { ReportButton } from './ReportButton';
+import { DeleteButton } from './DeleteButton';
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-monokai';
@@ -26,6 +27,7 @@ import {
   isCodeCompressed,
 } from './utils';
 import { AwesomeButton } from './AwesomeButton';
+import { request } from 'https';
 
 hljs.registerLanguage('js', javascriptHLJS);
 
@@ -115,6 +117,7 @@ export const DweetCard: React.FC<Props> = (props) => {
 
   const dweet: Dweet = (updatedDweet ? updatedDweet : props.dweet) || {
     id: -1,
+    deleted: false,
     code: '',
     awesome_count: 0,
     author: {
@@ -178,6 +181,20 @@ export const DweetCard: React.FC<Props> = (props) => {
     }
   }, [code, setError, error]);
 
+  if (dweet.deleted) {
+    return (
+      <div className="card p-3 mb-3">
+        <div className="d-flex align-items-center mb-3">
+          <span style={{ textAlign: 'left' }}>
+            [ this dweet no longer exists ]
+          </span>
+          <div style={{ flex: 1 }} />
+          <RemixOf dweet={dweet} />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="card p-3 mb-3">
       <div
@@ -238,10 +255,37 @@ export const DweetCard: React.FC<Props> = (props) => {
             <AwesomeButton dweet={dweet} onUpdate={setUpdatedDweet} />
           </div>
         </div>
-        <ReportButton
-          dweetId={dweet.id}
-          isEmptyStateDweet={isEmptyStateDweet}
-        />
+        {context.user && dweet.author.id == context?.user.id ? (
+          // Swap report button with delete for your own dweet
+          <DeleteButton
+            dweetId={dweet.id}
+            isEmptyStateDweet={isEmptyStateDweet}
+            onDeleted={() => {
+              setUpdatedDweet({ ...dweet, deleted: true });
+            }}
+          />
+        ) : (
+          <>
+            {context.user &&
+              context?.user.is_staff && ( // Extra delete button for mods
+                <span>
+                  <DeleteButton
+                    dweetId={dweet.id}
+                    isEmptyStateDweet={isEmptyStateDweet}
+                    onDeleted={() => {
+                      setUpdatedDweet({ ...dweet, deleted: true });
+                    }}
+                  />
+                </span>
+              )}
+            <div style={{ marginLeft: 16 }}>
+              <ReportButton
+                dweetId={dweet.id}
+                isEmptyStateDweet={isEmptyStateDweet}
+              />
+            </div>
+          </>
+        )}
         <a
           href="#"
           style={{
@@ -258,7 +302,7 @@ export const DweetCard: React.FC<Props> = (props) => {
             setShowShareModal(true);
           }}
         >
-          Share
+          share
         </a>
         {dweet.remixes.length > 0 && (
           <a
@@ -296,29 +340,13 @@ export const DweetCard: React.FC<Props> = (props) => {
             iframeContainer?.requestFullscreen();
           }}
         >
-          Fullscreen
+          fullscreen
         </a>
       </div>
       <div className="d-flex align-items-center mb-3">
         <UserView user={dweet.author} />
         <div style={{ flex: 1 }} />
-        {dweet.remix_of && (
-          <>
-            <span>Remix of </span>
-            <Link to={'/d/' + dweet.remix_of.id} className="no-link-color mx-2">
-              <span
-                style={{
-                  opacity: '0.5',
-                }}
-              >
-                d/
-              </span>
-              {dweet.remix_of.id}
-            </Link>
-            <span className="mr-2"> by </span>
-            <UserViewRight user={dweet.remix_of.author} />
-          </>
-        )}
+        <RemixOf dweet={dweet} />
       </div>
       <div
         style={{
@@ -496,12 +524,14 @@ export const DweetCard: React.FC<Props> = (props) => {
                 : 'none',
           }}
         >
-          <Linkify componentDecorator={(decoratedHref, decoratedText, key) => (
-            <a target="_blank" href={decoratedHref} key={key}>
-              {decoratedText}
-            </a>
-           )}>
-           {dweet.comments[0].text}
+          <Linkify
+            componentDecorator={(decoratedHref, decoratedText, key) => (
+              <a target="_blank" href={decoratedHref} key={key}>
+                {decoratedText}
+              </a>
+            )}
+          >
+            {dweet.comments[0].text}
           </Linkify>
         </div>
       )}
@@ -519,100 +549,15 @@ export const DweetCard: React.FC<Props> = (props) => {
         </div>
       )}
       {comments.slice(shouldStickyFirstComment ? 1 : 0).map((comment) => {
-        let originalText = comment.text;
-        let parts: { text: string; type: 'text' | 'code' }[] = [
-          { text: '', type: 'text' },
-        ];
-        let isInsideBacktickPair = false;
-        let j = 0;
-        while (j < originalText.length) {
-          const letter = originalText[j];
-          if (letter === '\\' && isInsideBacktickPair) {
-            if (originalText[j + 1] === '`') {
-              parts[parts.length - 1].text += '`';
-              j += 2;
-              continue;
-            }
-          }
-          if (letter === '`') {
-            if (!isInsideBacktickPair) {
-              isInsideBacktickPair = true;
-              j++;
-              parts.push({ text: '', type: 'code' });
-              continue;
-            } else {
-              isInsideBacktickPair = false;
-              j++;
-              parts.push({ text: '', type: 'text' });
-              continue;
-            }
-          }
-
-          parts[parts.length - 1].text += letter;
-          j++;
-        }
-
         return (
-          <div
-            key={comment.id}
-            style={{ marginTop: 16 }}
-            className="hover-parent"
-          >
-            <div
-              className="hover-parent"
-              style={{
-                float: 'right',
-                padding: '2px 8px',
-                fontSize: 10,
-                borderRadius: 4,
-                background: '#f5f5f5',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <div className="show-on-parent-hover">
-                <ReportButton
-                  commentId={comment.id}
-                  isEmptyStateDweet={isEmptyStateDweet}
-                />
-              </div>
-            </div>
-            <UserView user={comment.author} />
-            <div style={{ marginLeft: 32 + 16 }}>
-              {parts.map((part, partKey) =>
-                part.type === 'code' ? (
-                  <code
-                    key={partKey}
-                    style={{
-                      display: 'inline-flex',
-                      background: 'hsl(0, 0%, 92.5%)',
-                      borderRadius: 4,
-                      padding: '2px 4px',
-                      fontSize: 12,
-                      flexWrap: 'wrap',
-                    }}
-                  >
-                    {hljs
-                      .highlight('js', part.text)
-                      .emitter.rootNode.children.map(
-                        (child: HLJSNode, i: number) => renderHLJSNode(child, i)
-                      )}
-                  </code>
-                ) : (
-                  <Linkify
-                    key={partKey}
-                    componentDecorator={(href, text, key) => (
-                      <Link target="_blank" key={key} to={href}>
-                        {text}
-                      </Link>
-                    )}
-                  >
-                    {part.text}
-                  </Linkify>
-                )
-              )}
-            </div>
-          </div>
+          <DweetCommentView
+            comment={comment}
+            deletePermission={
+              context.user && comment.author.id == context?.user.id
+            }
+            moderator={context?.user ? context?.user.is_staff : false}
+            isEmptyStateDweet={isEmptyStateDweet}
+          />
         );
       })}
       <form
@@ -755,6 +700,173 @@ export const DweetCard: React.FC<Props> = (props) => {
       </Modal>
     </div>
   );
+};
+
+const DweetCommentView: React.FC<{
+  comment: DweetComment;
+  deletePermission: boolean | null;
+  isEmptyStateDweet: boolean;
+  moderator: boolean;
+}> = ({ comment, deletePermission, moderator, isEmptyStateDweet }) => {
+  let originalText = comment.text;
+  let parts: { text: string; type: 'text' | 'code' }[] = [
+    { text: '', type: 'text' },
+  ];
+  let isInsideBacktickPair = false;
+  let j = 0;
+  const [deleted, setDeleted] = useState(false);
+
+  if (deleted) {
+    return null;
+  }
+
+  while (j < originalText.length) {
+    const letter = originalText[j];
+    if (letter === '\\' && isInsideBacktickPair) {
+      if (originalText[j + 1] === '`') {
+        parts[parts.length - 1].text += '`';
+        j += 2;
+        continue;
+      }
+    }
+    if (letter === '`') {
+      if (!isInsideBacktickPair) {
+        isInsideBacktickPair = true;
+        j++;
+        parts.push({ text: '', type: 'code' });
+        continue;
+      } else {
+        isInsideBacktickPair = false;
+        j++;
+        parts.push({ text: '', type: 'text' });
+        continue;
+      }
+    }
+
+    parts[parts.length - 1].text += letter;
+    j++;
+  }
+  return (
+    <div key={comment.id} style={{ marginTop: 16 }} className="hover-parent">
+      <div
+        className="hover-parent"
+        style={{
+          float: 'right',
+          padding: '2px 8px',
+          fontSize: 10,
+          borderRadius: 4,
+          background: '#f5f5f5',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div className="show-on-parent-hover">
+          {deletePermission ? (
+            <DeleteButton
+              commentId={comment.id}
+              onDeleted={() => {
+                setDeleted(true);
+              }}
+              isEmptyStateDweet={isEmptyStateDweet}
+            />
+          ) : (
+            <>
+              <ReportButton
+                commentId={comment.id}
+                isEmptyStateDweet={isEmptyStateDweet}
+              />
+              {moderator && ( // Mods get both buttons! :)
+                <div style={{ marginLeft: 16 }}>
+                  <DeleteButton
+                    commentId={comment.id}
+                    onDeleted={() => {
+                      setDeleted(true);
+                    }}
+                    isEmptyStateDweet={isEmptyStateDweet}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+      <UserView user={comment.author} />
+      <div style={{ marginLeft: 32 + 16 }}>
+        {parts.map((commentPart, partKey) =>
+          commentPart.type === 'code' ? (
+            <code
+              key={partKey}
+              style={{
+                display: 'inline-flex',
+                background: 'hsl(0, 0%, 92.5%)',
+                borderRadius: 4,
+                padding: '2px 4px',
+                fontSize: 12,
+                flexWrap: 'wrap',
+              }}
+            >
+              {hljs
+                .highlight('js', commentPart.text)
+                .emitter.rootNode.children.map((child: HLJSNode, i: number) =>
+                  renderHLJSNode(child, i)
+                )}
+            </code>
+          ) : (
+            <Linkify
+              key={partKey}
+              componentDecorator={(href, text, key) => (
+                <Link target="_blank" key={key} to={href}>
+                  {text}
+                </Link>
+              )}
+            >
+              {commentPart.text}
+            </Linkify>
+          )
+        )}
+      </div>
+    </div>
+  );
+};
+
+const RemixOf: React.FC<{ dweet: Dweet }> = ({ dweet }) => {
+  if (!dweet.remix_of) {
+    return <></>;
+  }
+  if (!dweet.remix_of.deleted) {
+    return (
+      <>
+        <span>Remix of </span>
+        <Link to={'/d/' + dweet.remix_of.id} className="no-link-color mx-2">
+          <span
+            style={{
+              opacity: '0.5',
+            }}
+          >
+            d/
+          </span>
+          {dweet.remix_of.id}
+        </Link>
+        <span className="mr-2"> by </span>
+        <UserViewRight user={dweet.remix_of.author} />
+      </>
+    );
+  } else {
+    return (
+      <>
+        <span>Remix of </span>
+        <Link to={'/d/' + dweet.remix_of.id} className="no-link-color mx-2">
+          <span
+            style={{
+              opacity: '0.5',
+            }}
+          >
+            [ deleted ]
+          </span>
+        </Link>
+      </>
+    );
+  }
 };
 
 const DweetList: React.FC<{ dweet_ids: number[] }> = ({ dweet_ids }) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@ export interface LoggedInUser {
   username: string;
   avatar: string;
   email: string;
+  is_staff: boolean;
 }
 
 export interface DweetComment {
@@ -19,10 +20,12 @@ export interface DweetComment {
   posted: string;
   author: User;
   reply_to: number;
+  deleted: boolean;
 }
 
 export interface Dweet {
   id: number;
+  deleted: boolean;
   code: string;
   posted: string;
   author: User;
@@ -78,6 +81,25 @@ async function post(path: string, options: { data?: any }) {
   return await response.json();
 }
 
+async function del(path: string) {
+  const token = localStorage.getItem('token');
+  const response = await fetch(process.env.REACT_APP_API_BASE_URL + path, {
+    method: 'delete',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...(token ? { Authorization: 'token ' + token } : {}),
+    },
+  });
+  if (token && response.status === 401) {
+    localStorage.removeItem('token');
+  }
+  if (!response.ok) {
+    throw await response.json();
+  }
+  return await response;
+}
+
 export async function getDweets(
   order_by: string,
   hashtag: string,
@@ -119,6 +141,14 @@ export async function setLike(id: number, like: boolean): Promise<Dweet> {
       like,
     },
   });
+}
+
+export async function deleteDweet(id: number) {
+  return del(`dweets/${id}`);
+}
+
+export async function deleteComment(id: number) {
+  return del(`comments/${id}`);
 }
 
 export async function login(


### PR DESCRIPTION
Delete your own dweets and comments. The delete button replaces the report button on dweets/comments you own yourself. Relies on API change to merge first. Missing extra delete button for mods to be active on all.

Own dweet:
<img width="557" alt="Screen Shot 2021-11-14 at 3 59 10 PM" src="https://user-images.githubusercontent.com/610925/141704168-5e17f2a3-c45b-486f-ba8f-db9907f7ac65.png">
Other's dweet:
<img width="565" alt="Screen Shot 2021-11-14 at 3 59 05 PM" src="https://user-images.githubusercontent.com/610925/141704173-284d6e15-ade6-4eec-9ba6-0da879ba8c8f.png">

Own comment:
<img width="533" alt="Screen Shot 2021-11-14 at 3 57 34 PM" src="https://user-images.githubusercontent.com/610925/141704180-b5a65dae-dc32-4e28-92bc-7e6cf8c3de86.png">


Fixes #20 

Also fixes #105 as it adds views for deleted dweets: 
<img width="633" alt="Screen Shot 2021-11-14 at 2 16 57 PM" src="https://user-images.githubusercontent.com/610925/141700906-d182b253-bc81-4894-a06a-a2635576d749.png">
<img width="194" alt="Screen Shot 2021-11-14 at 2 16 52 PM" src="https://user-images.githubusercontent.com/610925/141700911-5abcadf3-cfd5-4e83-84af-e80c7efde17f.png">
<img width="608" alt="Screen Shot 2021-11-14 at 2 17 09 PM" src="https://user-images.githubusercontent.com/610925/141700912-3a70e98f-6d6c-4ea4-a822-f160d9e4673d.png">

