### PR TITLE
Give the "share" link a real URL

### DIFF
--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -287,7 +287,7 @@ export const DweetCard: React.FC<Props> = (props) => {
         )}
         <a
           // We make this a link, so users can ctrl-click to open in a new tab
-          href={'https://dwitter.net/d/' + dweet.id}
+          href={'/d/' + dweet.id}
           style={{
             marginLeft: 16,
             ...(isEmptyStateDweet

--- a/src/DweetCard.tsx
+++ b/src/DweetCard.tsx
@@ -286,7 +286,8 @@ export const DweetCard: React.FC<Props> = (props) => {
           </>
         )}
         <a
-          href="#"
+          // We make this a link, so users can ctrl-click to open in a new tab
+          href={'https://dwitter.net/d/' + dweet.id}
           style={{
             marginLeft: 16,
             ...(isEmptyStateDweet


### PR DESCRIPTION
This should allow it to be Ctrl-clicked or right-clicked, to open in a new tab.

(I appreciate that this feature is already present on the dweet's date, as it should be, but I think it's good to have it here too. This achieves parity with the original dweet front-end.)

There is an `e.preventDefault()` so I don't think this link will be followed on a normal click.

However, I'm just editing the code on GitHub. I haven't actually tested it! :crossed_fingers: 